### PR TITLE
rename job

### DIFF
--- a/.github/workflows/test_on_postgis-2.5.yml
+++ b/.github/workflows/test_on_postgis-2.5.yml
@@ -3,7 +3,7 @@ name: test_on_postgis_2.5
 on: [push, pull_request]
 
 jobs:
-  test_on_postgis_2.5:
+  test_on_postgis_25:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test_on_postgis-2.5.yml
+++ b/.github/workflows/test_on_postgis-2.5.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         dotnet-version: ['2.1.x' ]
-        postgis-version: ['postgis/postgis:12-2.5-alpine', 'postgis/postgis:11-2.5-alpine', 'postgis/postgis:10-2.5-alpine', '9.6-2.5-alpine' ]
+        postgis-version: ['postgis/postgis:12-2.5-alpine', 'postgis/postgis:11-2.5-alpine', 'postgis/postgis:10-2.5-alpine', 'postgis/postgis:9.6-2.5-alpine' ]
     services:
       postgis:
         image: ${{ matrix.postgis-version }}

--- a/.github/workflows/test_on_postgis-3.0.yml
+++ b/.github/workflows/test_on_postgis-3.0.yml
@@ -3,7 +3,7 @@ name: test_on_postgis_3.0
 on: [push, pull_request]
 
 jobs:
-  test_on_postgis_3.0:
+  test_on_postgis_30:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test_on_postgis-3.1.yml
+++ b/.github/workflows/test_on_postgis-3.1.yml
@@ -3,7 +3,7 @@ name: test_on_postgis_3.1
 on: [push, pull_request]
 
 jobs:
-  test_on_postgis_3.1:
+  test_on_postgis_31:
 
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Many tests failed.
The number of failed test is different on various postgis,eg 
postgis 3.1
```
Total tests: 206
     Passed: 190
     Failed: 16
```
postgis 3.0
```
Test Run Failed.
Total tests: 206
     Passed: 204
     Failed: 2
```
postgis 2.5
```
Total tests: 206
     Passed: 195
     Failed: 11
```
The test log is like 
```
  Stack Trace:
     at LinqToDBPostGisNetTopologySuite.Tests.SpatialReferenceSystemFunctionsTests.TestSTSetSrId() in /home/runner/work/linq2db-postgis-extensions/linq2db-postgis-extensions/LinqToDBPostGisNetTopologySuite.Tests/SpatialReferenceSystemFunctionsTests.cs:line 35

  X TestSTTransform [39ms]
  Error Message:
     Expected string length 185 but was 193. Strings differ at index 42.
  Expected: "....1776848522251 42.3902896512902,-71.1776843766326 42.39038..."
  But was:  "....1776848522251 42.39028965129018,-71.17768437663261 42.390..."
```