### PR TITLE
Add STProject method with test

### DIFF
--- a/LinqToDBPostGisNetTopologySuite.Tests/MeasurementFunctionsTests.cs
+++ b/LinqToDBPostGisNetTopologySuite.Tests/MeasurementFunctionsTests.cs
@@ -7,6 +7,7 @@ using NTSGS = NetTopologySuite.Geometries;
 using NTSG = NetTopologySuite.Geometries.Geometry;
 
 using LinqToDBPostGisNetTopologySuite.Tests.Entities;
+using System;
 
 namespace LinqToDBPostGisNetTopologySuite.Tests
 {
@@ -603,6 +604,28 @@ namespace LinqToDBPostGisNetTopologySuite.Tests
                 Assert.AreEqual(105.465793597674, db.Select(() => MeasurementFunctions.ST3DPerimeter(Ewkt)), 1.0E-9);
 
                 Assert.IsNull(db.Select(() => MeasurementFunctions.ST3DPerimeter((NTSG)null)));
+            }
+        }
+
+        [Test]
+        public void TestSTProject()
+        {
+            const string wkt = "POINT(0 0)";
+            using (var db = new PostGisTestDataConnection(TestDatabaseConnectionString))
+            {
+                var result1 = db.Select(() => MeasurementFunctions.STProject(GeometryInput.STGeomFromText(wkt),100000,(Math.PI/180.0)*45.0)) as NTSGS.Point;
+                var result2 = db.Select(() => MeasurementFunctions.STProject(wkt, 100000, (Math.PI / 180.0) * 45.0)) as NTSGS.Point;
+                var result3 = db.Select(() => MeasurementFunctions.STProject((NTSG)null, 100000, (Math.PI / 180.0) * 45.0)) as NTSGS.Point;
+
+                Assert.IsNotNull(result1);
+                Assert.AreEqual(0.635231029125537,result1.X,1.0E-5);
+                Assert.AreEqual(0.639472334729198,result1.Y,1.0E-5);
+
+                Assert.IsNotNull(result2);
+                Assert.AreEqual(0.635231029125537,result2.X,1.0E-5);
+                Assert.AreEqual(0.639472334729198,result2.Y,1.0E-5);
+
+                Assert.IsNull(result3);
             }
         }
 

--- a/LinqToDBPostGisNetTopologySuite/MeasurementFunctions.cs
+++ b/LinqToDBPostGisNetTopologySuite/MeasurementFunctions.cs
@@ -752,7 +752,37 @@ namespace LinqToDBPostGisNetTopologySuite
             throw new InvalidOperationException();
         }
 
-        // TODO: ST_Project(geography)
+        /// <summary>
+        /// Returns a point projected from a start point along a geodesic using a given distance and azimuth (bearing)
+        /// </summary>
+        /// <remarks>
+        /// See https://postgis.net/docs/ST_Project.html
+        /// </remarks>
+        /// <param name="geography">Input geography</param>
+        /// <param name="distance">Distance given in meters.Negative values are supported</param>
+        /// <param name="azimuth">Azimuth (bearing) given in radians, measured clockwise.Negative values and values greater than 2π (360 degrees) are supported</param>
+        /// <returns>Point projected</returns>
+        [Sql.Function("ST_Project", ServerSideOnly = true)]
+        public static NTSG STProject(this NTSG geography, double distance, double azimuth)
+        {
+            throw new InvalidOperationException();
+        }
+
+        /// <summary>
+        /// Returns a point projected from a start point along a geodesic using a given distance and azimuth (bearing)
+        /// </summary>
+        /// <remarks>
+        /// See https://postgis.net/docs/ST_Project.html
+        /// </remarks>
+        /// <param name="geography">Input geography</param>
+        /// <param name="distance">Distance given in meters.Negative values are supported</param>
+        /// <param name="azimuth">Azimuth (bearing) given in radians, measured clockwise.Negative values and values greater than 2π (360 degrees) are supported</param>
+        /// <returns>Point projected</returns>
+        [Sql.Function("ST_Project", ServerSideOnly = true)]
+        public static NTSG STProject(string geography, double distance, double azimuth)
+        {
+            throw new InvalidOperationException();
+        }
 
         /// <summary>
         /// Returns the 2D shortest line between two input geometries.


### PR DESCRIPTION
[st_project](https://postgis.net/docs/ST_Project.html), a  geography input/output method added.Call STProject(a,b,c) will take a geometry input and trigger type casting at PostGIS.

PostgreSQL will usually cast  geometry/ geography as needed.

Behavior here:

geometry -> geography [ automatic ](https://postgis.net/docs/geometry.html) 
geography  -> geometry  [explicit](https://postgis.net/docs/geography.html)

```
SELECT ST_AsText(ST_Project('POINT(0 0)', 100000, radians(45.0)));
POINT(0.635231029125537 0.639472334729198)
SELECT ST_AsText(ST_Project('POINT(0 0)'::geography, 100000, radians(45.0)));
POINT(0.635231029125537 0.639472334729198)
```
Releated doc here:
[npgsql spatial mapping](https://www.npgsql.org/doc/types/nts.html)
[PostGIS geo data types](https://postgis.net/docs/reference.html#PostGIS_Types)

